### PR TITLE
Fix for timezone aware datetimes in Django 1.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ django-undelete
 
 UnDelete is a simple project that gives you access to a TrashableMixin meta model and some useful managers as well.
 
-Much of the work is heavily derivative of Simon Willison's [post on the same topic](http://ltslashgt.com/2007/07/18/undelete-in-django/).
+Much of the work is heavily derivative of Nathan Ostgard's [post on the same topic](http://ltslashgt.com/2007/07/18/undelete-in-django/).
 
 Installation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "django-undelete",
-    version = "0.1",
+    version = "1.0.0",
     packages = find_packages(),
     install_requires = ['django>=1.3'],
 )

--- a/undelete/models.py
+++ b/undelete/models.py
@@ -26,15 +26,3 @@ class TrashableMixin(models.Model):
             
     class Meta:
         abstract = True
-
-	def delete(self, *args, **kwargs, trash=True):
-	    if not self.trashed_at and trash:
-	        self.trashed_at = datetime.now()
-	        self.save()
-	    else:
-	    	super(TrashableMixin, self).delete(*args, **kwargs)
-
-	def restore(self, commit=True):
-		self.trashed_at = None
-		if commit:
-			self.save()

--- a/undelete/models.py
+++ b/undelete/models.py
@@ -1,6 +1,9 @@
-from datetime import datetime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils import timezone as datetime
+except ImportError:
+    from datetime import datetime
 
 from undelete.managers import TrashedManager, NonTrashedManager
 

--- a/undelete/models.py
+++ b/undelete/models.py
@@ -15,7 +15,7 @@ class TrashableMixin(models.Model):
 	        self.trashed_at = datetime.now()
 	        self.save()
 	    else:
-			super(SomeModel, self).delete(*args, **kwargs)
+	    	super(TrashableMixin, self).delete(*args, **kwargs)
 
 	def restore(self, commit=True):
 		self.trashed_at = None


### PR DESCRIPTION
Updated models.py to use timezone safe datetime in django if available, otherwise fallback to the standard datetime. Maintains backwards compatibility with Django 1.3.
